### PR TITLE
Update to Comply with Steam's new "Challenge" response

### DIFF
--- a/lib/steam-server-status.js
+++ b/lib/steam-server-status.js
@@ -14,31 +14,51 @@ var util = require('util');
  */
 function getServerStatus(serverAddress, port, callback) {
     var client = dgram.createSocket("udp4");
-    var message = createInfoQueryBuffer();
-    
+    //New Challenge Buffer to save the challenge response
+    var challenge = Buffer.allocUnsafe(9);
+    var message = createInfoQueryBuffer(challenge);
+
+
     client.on('message', function(msg, rinfo) {
-        var serverInfo = parseServerInfo(serverAddress, port, msg);
-        clearTimeout(timeoutId);
-        client.close();
-        callback(serverInfo);
+        //if msg < 10 we've gotten the Challenge Number. In this case challenge gets updated with the challenge response, message gets refreshed and the second call is initiated
+        if (msg.length < 10) {
+            challenge = msg;
+            message = createInfoQueryBuffer(challenge);
+            call();
+        } else {
+            var serverInfo = parseServerInfo(serverAddress, port, msg);
+            clearTimeout(timeoutId);
+            client.close();
+            callback(serverInfo);
+        }
     });
 
     client.on('error', function(exception) {
         callbackAndClose("Failed to connect to steam server." + exception, 
             timeoutId, client, callback);
     });
-    
-    client.send(message, 0, message.length, port, serverAddress, function (error, bytes) {
-        if (error)
-            callbackAndClose("Unknown error occurred." + error, 
-                timeoutId, client, callback);
-    });
+
+    /**
+     * Packs message to server in function to re-use it
+     */
+    function call() {
+        client.send(message, 0, message.length, port, serverAddress, function (error, bytes) {
+            if (error)
+                callbackAndClose("Unknown error occurred." + error,
+                    timeoutId, client, callback);
+        });
+    }
 
     //try to handle a connect that we want to timeout.
     var timeoutId = setTimeout(function() {
         callbackAndClose("Connection to server timed out.", 
             timeoutId, client, callback);
-    }, 3000);
+    }, 8000);
+
+    /**
+     * initiate the actual functionality by starting the first call
+     */
+    call();
 }
 
 /**
@@ -114,7 +134,7 @@ function parseServerInfo(hostname, port, message) {
         serverName: serverName,
         map: map,
         gameDirectory: gameDirectory,
-        gameName: extractGameNameFromDirectory(gameDirectory),
+        gameName: gameDirectory,
         gameDescription: gameDescription,
         applicationId: appId,
         numberOfPlayers: numberOfPlayers,
@@ -125,7 +145,7 @@ function parseServerInfo(hostname, port, message) {
         passwordRequired: passwordRequired > 0,
         secure: secure > 0,
         gameVersion: gameVersion,
-        connectUrl: getConnectUrl(hostname, port),
+        connectUrl: getConnectUrl(hostname, port, ""),
         hostname: hostname,
         port: port
     }
@@ -171,8 +191,8 @@ function toHexString(byte) {
  * This generates a info query buffer object.
  * There is probably a cleaner way to generate this.
  */
-function createInfoQueryBuffer() {
-    var buffer = new Buffer(25);
+function createInfoQueryBuffer(challenge) {
+    var buffer = Buffer.allocUnsafe(25+4);
     buffer[0] = 0xFF;
     buffer[1] = 0xFF;
     buffer[2] = 0xFF;
@@ -198,5 +218,10 @@ function createInfoQueryBuffer() {
     buffer[22] = 0x72;
     buffer[23] = 0x79;
     buffer[24] = 0x00;
+    //challenge number
+    buffer[25] = challenge[5];
+    buffer[26] = challenge[6];
+    buffer[27] = challenge[7];
+    buffer[28] = challenge[8];
     return buffer;
 }


### PR DESCRIPTION
Adds support for Steam's new challenge response.
--> Buffer gets 4 extra fields for challenge number
--> call needs to be made twice (1st time to get challenge number, second to use it and get actual data)

--> Update to Buffer use as suggested by JSdocks
--> took out game directory parse because it crashed my system and did nothing of use (function still in there but unused)

--> no change in how to use, so backwards compatible. if old server doesn't give challenge, the second call wont be initiated